### PR TITLE
Use typing.TYPE_CHECKING and optimize imports

### DIFF
--- a/src/medusa/data.py
+++ b/src/medusa/data.py
@@ -1,15 +1,20 @@
-from .filters import Filters
-from .suite import Status, Suite
+from typing import TYPE_CHECKING
+
+from .suite import Status
 from .utils import Stats, Timer
+
+if TYPE_CHECKING:
+    from .filters import Filters
+    from .suite import Suite
 
 
 class Stage(Stats, Timer):
     def __init__(self, name: str) -> None:
         super().__init__(t_name=f"stage {name}")
         self.name = name
-        self.suites: list[Suite] = []
+        self.suites: "list[Suite]" = []
 
-    def insert(self, s: Suite):
+    def insert(self, s: "Suite"):
         self.add_stats(s)
         self.suites.append(s)
 
@@ -27,12 +32,12 @@ class Stage(Stats, Timer):
 
 
 class Data(Stats):
-    def __init__(self, filters: Filters) -> None:
+    def __init__(self, filters: "Filters") -> None:
         super().__init__()
         self.filters = filters
         self.stages: dict[str, Stage] = {}
 
-    def insert(self, s: Suite):
+    def insert(self, s: "Suite"):
         if self.filters.match_and_narrow(s):
             self.add_stats(s)
             self.stages.setdefault(s.stage, Stage(s.stage)).insert(s)

--- a/src/medusa/filters.py
+++ b/src/medusa/filters.py
@@ -1,10 +1,14 @@
 import re
 from enum import StrEnum
-from typing import Self
+from typing import TYPE_CHECKING
 
 from .constants import META_RE
 from .errors import MedusaError
-from .suite import Suite
+
+if TYPE_CHECKING:
+    from typing import Self
+
+    from .suite import Suite
 
 
 class Operator(StrEnum):
@@ -46,7 +50,7 @@ class FilterExpr:
         self.excl = excl
 
     @classmethod
-    def from_arg(cls, arg: str) -> Self:
+    def from_arg(cls, arg: str) -> "Self":
         pattern = r"(?P<flt>deps|stage)(?P<op>[=~])(?P<vals>.+)"
 
         matches = re.fullmatch(pattern, arg)
@@ -89,7 +93,7 @@ class Filters:
                 self._deps_excl |= flt.excl
                 self._deps_incl |= flt.incl
 
-    def match_and_narrow(self, s: Suite) -> bool:
+    def match_and_narrow(self, s: "Suite") -> bool:
         """Checks whether the suite is allowed to run based on the filter rules
         and narrows dynamic deps if necessary to match the filter criteria.
 

--- a/src/medusa/main.py
+++ b/src/medusa/main.py
@@ -1,20 +1,18 @@
 import logging
 import sys
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from docopt import docopt  # type: ignore
 
 from .constants import OUTPUTDIR, REPO_LINK, T_HARD, T_KILL
-from .data import Data
 from .errors import MedusaError
-from .filters import Filters
-from .robot import fetch_robot_data, merge_results
-from .runner import Runner
-from .settings import Settings
-from .stats import print_stats
-from .utils import LOGGER, Timeout
-from .version import __version__
-from .visual import write_visualization
+from .utils import LOGGER
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from .data import Data
+    from .settings import Settings
 
 HELP = f"""Medusa: Run Robot Framework suites with depdendency-aware parallelization
 
@@ -128,8 +126,16 @@ def main() -> None:
             else:
                 print(HELP)
         elif arguments["version"]:
+            from .version import __version__
+
             print(__version__)
         else:
+            from pathlib import Path
+
+            from .filters import Filters
+            from .settings import Settings
+            from .utils import Timeout
+
             filters = Filters(arguments["--filter"])
             outputdir = Path(arguments["--outputdir"])
             robotargs = arguments["ROBOTARGS"]
@@ -147,8 +153,12 @@ def main() -> None:
         exit(1)
 
 
-def run(settings: Settings):
-    data: Data = fetch_robot_data(settings)
+def run(settings: "Settings"):
+    from .robot import fetch_robot_data, merge_results
+    from .runner import Runner
+    from .visual import write_visualization
+
+    data: "Data" = fetch_robot_data(settings)
 
     if data.n_tests <= 0:
         raise MedusaError("No tests found, nothing to run!")
@@ -168,8 +178,11 @@ def run(settings: Settings):
     print(f"Results: {format_path(settings.outputdir)}")
 
 
-def stats(settings: Settings, selection: str):
-    data: Data = fetch_robot_data(settings)
+def stats(settings: "Settings", selection: str):
+    from .robot import fetch_robot_data
+    from .stats import print_stats
+
+    data: "Data" = fetch_robot_data(settings)
     print_stats(data, selection)
 
 
@@ -191,7 +204,7 @@ def configure_logging(log_level: int):
     LOGGER.addHandler(stream_handler)
 
 
-def add_file_logger(settings: Settings):
+def add_file_logger(settings: "Settings"):
     log_file = settings.outputdir / "medusa.log"
 
     # We use the same formatter as the StreamHandler
@@ -206,7 +219,7 @@ def add_file_logger(settings: Settings):
     LOGGER.addHandler(file_handler)
 
 
-def format_path(path: Path) -> str:
+def format_path(path: "Path") -> str:
     """If stdout is a tty, the path is wrapped as a OSC 8 link to make
     terminals recognise it.
     """

--- a/src/medusa/robot.py
+++ b/src/medusa/robot.py
@@ -3,22 +3,26 @@ import re
 import sys
 from io import StringIO
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING
 
 from robot import running
 from robot.api import SuiteVisitor
-from robot.errors import Information  # type: ignore
-from robot.rebot import rebot  # type: ignore
 from robot.run import RobotFramework  # type: ignore
 
 from .data import Data
 from .robot_reader import RobotSuiteWalker
-from .settings import Settings
-from .suite import Suite
 from .utils import LOGGER, Timer
 
+if TYPE_CHECKING:
+    from typing import Any
 
-def fetch_robot_data(settings: Settings) -> Data:
+    from .settings import Settings
+    from .suite import Suite
+
+
+def fetch_robot_data(settings: "Settings") -> "Data":
+    from robot.errors import Information  # type: ignore
+
     t = Timer("processing suite data")
     t.timer_start()
 
@@ -77,7 +81,7 @@ def fetch_robot_data(settings: Settings) -> Data:
     return data
 
 
-def _get_pretty_metadata(suite: Suite) -> dict[str, str]:
+def _get_pretty_metadata(suite: "Suite") -> dict[str, str]:
     """Get a dictionary representation of suite metadata as it was resolved
     with variables all resolved and lists flattened.
     """
@@ -94,7 +98,7 @@ def _get_pretty_metadata(suite: Suite) -> dict[str, str]:
     return metadata
 
 
-def run_suite(suite: Suite, settings: Settings):
+def run_suite(suite: "Suite", settings: "Settings"):
     # Get independent process group, otherwise any interrupt that the parent
     # receives is also received by this process
     os.setsid()
@@ -159,7 +163,7 @@ def run_suite(suite: Suite, settings: Settings):
 
 
 class SuitePrepModifier(SuiteVisitor):
-    def __init__(self, target_suite: Suite | None = None):
+    def __init__(self, target_suite: "Suite|None" = None):
         super().__init__()
         self.suffix: str | None = None
         self.metadata: dict[str, str] | None = None
@@ -170,7 +174,7 @@ class SuitePrepModifier(SuiteVisitor):
             self.metadata = _get_pretty_metadata(target_suite)
             self.source = target_suite.source.resolve()
 
-    def start_suite(self, suite: running.TestSuite):
+    def start_suite(self, suite: "running.TestSuite"):
         # Edge case: If we execute a single medusa:for suite file, we end up
         # having multiple root suites with different names (because we change
         # the name). In this case, we need to artificially create a parent.
@@ -222,7 +226,7 @@ class SuitePrepModifier(SuiteVisitor):
 class SuitePrepDeleter(SuiteVisitor):
     """Deletes empty suites and sets the correct execution mode."""
 
-    def start_suite(self, suite: running.TestSuite):
+    def start_suite(self, suite: "running.TestSuite"):
         # Robot adds all the other suites that were specified as command line
         # arguments, even though we use `parseinclude` to only run a single
         # suite. They are simply empty suites though (besides an edge case
@@ -256,6 +260,8 @@ def merge_results(results_path: Path) -> None:
 
     If any other error is encountered, the merge is aborted.
     """
+    from robot.rebot import rebot  # type: ignore
+
     t = Timer("merging results")
     t.timer_start()
 

--- a/src/medusa/robot_handler.py
+++ b/src/medusa/robot_handler.py
@@ -1,10 +1,12 @@
 from abc import ABC, abstractmethod
-from typing import Any
-
-from robot import running
-from robot.libraries.BuiltIn import BuiltIn  # type: ignore
+from typing import TYPE_CHECKING
 
 from .errors import MetadataError, VariableError
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from robot import running
 
 
 class UndefinedType(object):
@@ -22,29 +24,31 @@ Undefined = UndefinedType()  # UndefinedType object, used like NoneType's None
 
 class RobotHandlerInterface(ABC):
     @abstractmethod
-    def set_variables(self, varmap: dict[str, Any]) -> None:
+    def set_variables(self, varmap: "dict[str, Any]") -> None:
         pass
 
     @abstractmethod
-    def replace_variables(self, s: str) -> Any:
+    def replace_variables(self, s: str) -> "Any":
         pass
 
     @abstractmethod
-    def get_variable_value(self, name: str) -> Any:
+    def get_variable_value(self, name: str) -> "Any":
         pass
 
     @abstractmethod
     def get_metadata(
-        self, suite: running.TestSuite, name: str, required: bool
+        self, suite: "running.TestSuite", name: str, required: bool
     ) -> str | None:
         pass
 
 
 class RobotHandler(RobotHandlerInterface):
     def __init__(self):
+        from robot.libraries.BuiltIn import BuiltIn  # type: ignore
+
         self._builtin = BuiltIn()
 
-    def set_variables(self, varmap: dict[str, Any]):
+    def set_variables(self, varmap: "dict[str, Any]"):
         for key, value in varmap.items():
             try:
                 self._builtin.set_suite_variable(f"${key}", value)
@@ -53,7 +57,7 @@ class RobotHandler(RobotHandlerInterface):
                     key, f"Failed to set value '{value}'", str(e)
                 )
 
-    def replace_variables(self, s: str) -> Any:
+    def replace_variables(self, s: str) -> "Any":
         """Replace all variables in the given string.
 
         If the string consists of a single variable, it will be returned
@@ -76,7 +80,7 @@ class RobotHandler(RobotHandlerInterface):
         except Exception as e:
             raise VariableError(s, str(e))
 
-    def get_variable_value(self, name: str) -> Any:
+    def get_variable_value(self, name: str) -> "Any":
         """Return value of variable. Returns Undefined if variable is unset.
         Raises VariableError if var is not a valid variable."""
         try:
@@ -94,7 +98,7 @@ class RobotHandler(RobotHandlerInterface):
         return val
 
     def get_metadata(
-        self, suite: running.TestSuite, name: str, required: bool
+        self, suite: "running.TestSuite", name: str, required: bool
     ) -> str | None:
         try:
             return suite.metadata[name]

--- a/src/medusa/robot_reader.py
+++ b/src/medusa/robot_reader.py
@@ -3,26 +3,33 @@ from collections import Counter
 from collections.abc import Iterable, Mapping
 from itertools import chain
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING
 
-from robot import running
 from robot.api.interfaces import ListenerV3
 
 from .constants import META_RE
-from .data import Data
 from .errors import MedusaError, MetadataError, SuiteError, VariableError
-from .robot_handler import RobotHandler, RobotHandlerInterface, Undefined
+from .robot_handler import RobotHandler, Undefined
 from .suite import DynDep, Suite
 from .utils import Timeout
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+    from typing import Any
+
+    from robot import running
+
+    from .data import Data
+    from .robot_handler import RobotHandlerInterface
+
 
 class RobotSuiteWalker(ListenerV3):
-    def __init__(self, data: Data, errors: list[str]):
+    def __init__(self, data: "Data", errors: list[str]):
         self.data = data
         self.errors = errors
         self.reader = RobotSuiteReader()
 
-    def start_suite(self, suite: running.TestSuite, _):
+    def start_suite(self, suite: "running.TestSuite", _):
         if not suite.tests:
             return  # For now we only process leaf suites that contain tests
 
@@ -34,7 +41,12 @@ class RobotSuiteWalker(ListenerV3):
         except Exception as e:
             self.errors.append(str(SuiteError(str(suite.source), str(e))))
 
-    def start_invalid_keyword(self, keyword, implementation, __):
+    def start_invalid_keyword(
+        self,
+        keyword: "running.Keyword",
+        implementation: "running.KeywordImplementation",
+        __,
+    ):
         self.errors.append(
             str(
                 MedusaError(
@@ -46,21 +58,21 @@ class RobotSuiteWalker(ListenerV3):
 
 
 class RobotSuiteReader:
-    def __init__(self, robot_handler: RobotHandlerInterface | None = None):
+    def __init__(self, robot_handler: "RobotHandlerInterface|None" = None):
         if robot_handler:
             self.robot_handler = robot_handler
         else:
             self.robot_handler = RobotHandler()
 
-    def get_suites(self, suite: running.TestSuite) -> list[Suite]:
+    def get_suites(self, suite: "running.TestSuite") -> "list[Suite]":
         if var_maps := self._get_for(suite):
             return [self._get_suite(suite, var_map) for var_map in var_maps]
         else:
             return [self._get_suite(suite, None)]
 
     def _get_suite(
-        self, suite: running.TestSuite, varmap: dict[str, Any] | None = None
-    ) -> Suite:
+        self, suite: "running.TestSuite", varmap: "dict[str, Any]|None" = None
+    ) -> "Suite":
         if varmap:
             self.robot_handler.set_variables(varmap)
 
@@ -88,7 +100,7 @@ class RobotSuiteReader:
             n_tests=n_tests,
         )
 
-    def _get_stage(self, suite: running.TestSuite) -> str:
+    def _get_stage(self, suite: "running.TestSuite") -> str:
         stage = self.robot_handler.get_metadata(suite, "medusa:stage", True)
         assert isinstance(stage, str)
 
@@ -106,8 +118,8 @@ class RobotSuiteReader:
         return stage
 
     def _get_deps(
-        self, suite: running.TestSuite
-    ) -> tuple[frozenset[str], dict[str, DynDep]]:
+        self, suite: "running.TestSuite"
+    ) -> "tuple[frozenset[str], dict[str, DynDep]]":
         """Get static and dynamic dependencies from suite metadata.
 
         First splits the metadata into individual arguments, tries to resolve
@@ -140,7 +152,7 @@ class RobotSuiteReader:
                     deps_values.append(str(resolved))
 
             deps_static: set[str] = set()
-            deps_dynamic: dict[str, DynDep] = {}
+            deps_dynamic: "dict[str, DynDep]" = {}
 
             for dep in deps_values:
                 if name_opts_tup := self._get_deps_dynamic(dep):
@@ -248,7 +260,7 @@ class RobotSuiteReader:
 
         return (varname, options)
 
-    def _get_timeout(self, suite: running.TestSuite) -> Timeout | None:
+    def _get_timeout(self, suite: "running.TestSuite") -> "Timeout|None":
         try:
             timeout_str = self.robot_handler.get_metadata(
                 suite, "medusa:timeout", False
@@ -262,8 +274,8 @@ class RobotSuiteReader:
             raise MetadataError("medusa:timeout", str(e))
 
     def _get_for(
-        self, suite: running.TestSuite
-    ) -> list[dict[str, Any]] | None:
+        self, suite: "running.TestSuite"
+    ) -> "list[dict[str, Any]]|None":
         try:
             args_str = self.robot_handler.get_metadata(
                 suite, "medusa:for", False
@@ -321,8 +333,8 @@ class RobotSuiteReader:
             raise MetadataError("medusa:for", str(e))
 
     def _get_for_from_mapping(
-        self, vars: list[str], mapping: Mapping
-    ) -> list[dict[str, Any]]:
+        self, vars: list[str], mapping: "Mapping"
+    ) -> "list[dict[str, Any]]":
         if len(vars) != 2:
             raise MetadataError(
                 "medusa:for",
@@ -332,10 +344,10 @@ class RobotSuiteReader:
         return maps
 
     def _get_for_from_iterable(
-        self, vars: list[str], iterable: Any
-    ) -> list[dict[str, Any]]:
+        self, vars: list[str], iterable: "Any"
+    ) -> "list[dict[str, Any]]":
         """Raises MetadataError if the value is not iterable"""
-        maps: list[dict[str, Any]] = []
+        maps: "list[dict[str, Any]]" = []
 
         try:
             source_iter = iter(iterable)

--- a/src/medusa/runner.py
+++ b/src/medusa/runner.py
@@ -6,13 +6,18 @@ import os
 import signal
 import sys
 from dataclasses import dataclass, field
-from typing import Any, Self
+from typing import TYPE_CHECKING
 
-from .data import Data, Stage, Status
+from .data import Status
 from .robot import run_suite
-from .settings import Settings
-from .suite import Suite
 from .utils import LOGGER, Timer
+
+if TYPE_CHECKING:
+    from typing import Any, Self
+
+    from .data import Data, Stage
+    from .settings import Settings
+    from .suite import Suite
 
 
 class _SignalMonitor:
@@ -36,7 +41,7 @@ class _SignalMonitor:
                 + " Further signals will be sent directly to running robot processes."
             )
 
-    def __enter__(self) -> Self:
+    def __enter__(self) -> "Self":
         signal.signal(signal.Signals.SIGINT, self)
         signal.signal(signal.Signals.SIGTERM, self)
         return self
@@ -50,7 +55,7 @@ SIGNAL_MONITOR = _SignalMonitor()
 
 
 class DepManager:
-    def __init__(self, stage: Stage):
+    def __init__(self, stage: "Stage"):
         all_deps: set[str] = set(stage.deps_static_cnt).union(
             stage.deps_dynamic_cnt
         )
@@ -58,7 +63,7 @@ class DepManager:
         self.available = set(all_deps)
         self.in_use: set[str] = set()
 
-    def try_lock(self, suite: Suite) -> bool:
+    def try_lock(self, suite: "Suite") -> bool:
         """Attempt to lock dependencies for the given suite. Returns True on
         success or False if not all necessary dependencies were available."""
         deps_assigned = suite.try_assign_deps(self.available)
@@ -73,7 +78,7 @@ class DepManager:
         self.in_use.update(deps_assigned)
         return True
 
-    def free(self, suite: Suite):
+    def free(self, suite: "Suite"):
         deps_assigned = suite.deps
         assert deps_assigned.issubset(self.all)
         assert deps_assigned.issubset(self.in_use)
@@ -84,23 +89,23 @@ class DepManager:
 
 @dataclass
 class ProcessInfo:
-    process: multiprocessing.Process
+    process: "multiprocessing.Process"
     interrupt_count: int = 0
-    start_time: datetime.datetime = field(
+    start_time: "datetime.datetime" = field(
         default_factory=datetime.datetime.now, init=False
     )
 
 
 @dataclass
 class ProcessManager:
-    settings: Settings
+    settings: "Settings"
 
     # map of sentinel: ProcessInfo
-    processes: dict[Any, ProcessInfo] = field(default_factory=dict)
-    suites: dict[Any, Suite] = field(default_factory=dict)
+    processes: "dict[Any, ProcessInfo]" = field(default_factory=dict)
+    suites: "dict[Any, Suite]" = field(default_factory=dict)
     running: bool = field(default=False)
 
-    def start(self, suite: Suite):
+    def start(self, suite: "Suite"):
         p = multiprocessing.Process(
             target=run_suite, args=(suite, self.settings)
         )
@@ -112,7 +117,7 @@ class ProcessManager:
         self.suites[p.sentinel] = suite
         self.running = True
 
-    def get_finished_suites(self) -> list[Suite]:
+    def get_finished_suites(self) -> "list[Suite]":
         ret = list()
         for sentinel in multiprocessing.connection.wait(
             self.processes.keys(), timeout=1.0
@@ -200,7 +205,7 @@ class ProcessManager:
 
 
 class Runner:
-    def __init__(self, settings: Settings, stage: Stage):
+    def __init__(self, settings: "Settings", stage: "Stage"):
         self.stage = stage
 
         self.depmgr = DepManager(stage)
@@ -212,7 +217,7 @@ class Runner:
             self.interactive = False
 
     @classmethod
-    def run(cls, settings: Settings, data: Data):
+    def run(cls, settings: "Settings", data: "Data"):
         t = Timer("execution")
         t.timer_start()
 

--- a/src/medusa/settings.py
+++ b/src/medusa/settings.py
@@ -1,14 +1,17 @@
 from dataclasses import dataclass
-from pathlib import Path
+from typing import TYPE_CHECKING
 
-from .filters import Filters
-from .utils import Timeout
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from .filters import Filters
+    from .utils import Timeout
 
 
 @dataclass(frozen=True)
 class Settings:
-    filters: Filters
+    filters: "Filters"
     log_level: int
-    outputdir: Path
+    outputdir: "Path"
     robotargs: list[str]
-    timeout: Timeout | None
+    timeout: "Timeout|None"

--- a/src/medusa/stats.py
+++ b/src/medusa/stats.py
@@ -1,11 +1,14 @@
 from collections import Counter
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from .data import Data
 from .errors import MedusaError
 
+if TYPE_CHECKING:
+    from .data import Data
 
-def print_stats(data: Data, selection: str) -> None:
+
+def print_stats(data: "Data", selection: str) -> None:
     try:
         selections: set[str] = set(selection.split(","))
     except Exception:
@@ -66,7 +69,7 @@ def print_stats(data: Data, selection: str) -> None:
             _print_static(data)
 
 
-def _print_suites(data: Data) -> None:
+def _print_suites(data: "Data") -> None:
     _print_title("Suites")
     for stage in sorted(data.stages.values(), key=lambda s: s.name):
         print("Stage", stage.name)
@@ -87,7 +90,7 @@ def _print_suites(data: Data) -> None:
         print()
 
 
-def _print_static(data: Data) -> None:
+def _print_static(data: "Data") -> None:
     _print_title("Static deps")
     for name, count in sorted(
         data.deps_static_cnt.items(), key=lambda name_count: name_count[0]
@@ -97,7 +100,7 @@ def _print_static(data: Data) -> None:
     print()
 
 
-def _print_dynamic(data: Data) -> None:
+def _print_dynamic(data: "Data") -> None:
     _print_title("Dynamic deps")
     for name, count in sorted(
         data.deps_dynamic_cnt.items(), key=lambda name_count: name_count[0]
@@ -107,7 +110,7 @@ def _print_dynamic(data: Data) -> None:
     print()
 
 
-def _print_totals(data: Data) -> None:
+def _print_totals(data: "Data") -> None:
     _print_title("Totals")
     print("Stages:", len(data.stages))
     print("Suites:", data.n_suites)
@@ -122,7 +125,7 @@ def _print_totals(data: Data) -> None:
     print()
 
 
-def _print_stages(data: Data) -> None:
+def _print_stages(data: "Data") -> None:
     _print_title("Stages")
     for s in sorted(data.stages.values(), key=lambda stage: stage.name):
         s_unit = "Suite" if s.n_suites == 1 else "Suites"
@@ -131,7 +134,7 @@ def _print_stages(data: Data) -> None:
     print()
 
 
-def _print_deps(data: Data) -> None:
+def _print_deps(data: "Data") -> None:
     _print_title("Deps")
     total: Counter[str] = Counter(data.deps_static_cnt)
     total.update(data.deps_dynamic_cnt)
@@ -145,7 +148,7 @@ def _print_deps(data: Data) -> None:
     print()
 
 
-def _print_tags(data: Data) -> None:
+def _print_tags(data: "Data") -> None:
     _print_title("Tags")
     for name, count in sorted(
         data.tags.items(), key=lambda name_count: name_count[0]

--- a/src/medusa/suite.py
+++ b/src/medusa/suite.py
@@ -2,11 +2,16 @@ import secrets
 from collections import Counter
 from enum import Enum, auto
 from itertools import chain
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING
 
 from .errors import MetadataError
-from .utils import Stats, Timeout, Timer
+from .utils import Stats, Timer
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from typing import Any
+
+    from .utils import Timeout
 
 
 class Status(Enum):
@@ -48,12 +53,12 @@ class Suite(Stats, Timer):
     def __init__(
         self,
         full_name: str,
-        source: Path,
+        source: "Path",
         stage: str,
         deps_static: frozenset[str],
         deps_dynamic: dict[str, DynDep],
-        timeout: Timeout | None,
-        for_vars: dict[str, Any] | None,
+        timeout: "Timeout|None",
+        for_vars: "dict[str, Any]|None",
         **kwargs,
     ) -> None:
         self.full_name = full_name

--- a/src/medusa/utils.py
+++ b/src/medusa/utils.py
@@ -4,12 +4,15 @@ from abc import ABC
 from collections import Counter
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from typing import Self
+from typing import TYPE_CHECKING
 
 from .constants import T_HARD, T_KILL
 from .errors import MedusaError
 
 LOGGER = logging.getLogger("medusa")
+
+if TYPE_CHECKING:
+    from typing import Self
 
 
 @dataclass
@@ -26,7 +29,7 @@ class Timeout:
         self.kill_total = self.hard_total + self.kill
 
     @classmethod
-    def from_argstr(cls, argstr: str | None) -> Self | None:
+    def from_argstr(cls, argstr: str | None) -> "Self|None":
         if not argstr:
             return None
 

--- a/src/medusa/visual.py
+++ b/src/medusa/visual.py
@@ -1,18 +1,12 @@
-import xml.etree.ElementTree as ET
-from datetime import datetime, timedelta
-from pathlib import Path
+from typing import TYPE_CHECKING
 
-import matplotlib.pyplot as plt
-from matplotlib.dates import (
-    MICROSECONDLY,
-    AutoDateLocator,
-    ConciseDateFormatter,
-)
+if TYPE_CHECKING:
+    from datetime import datetime
+    from pathlib import Path
 
-from .data import Data
-from .settings import Settings
-from .suite import Status, Suite
-from .utils import Timer
+    from .data import Data
+    from .settings import Settings
+    from .suite import Suite
 
 CSS = """
 svg {
@@ -39,7 +33,10 @@ Duration: {duration}
 """
 
 
-def write_visualization(settings: Settings, data: Data) -> None:
+def write_visualization(settings: "Settings", data: "Data") -> None:
+    from .suite import Status
+    from .utils import Timer
+
     t = Timer("writing visualization")
     t.timer_start()
 
@@ -52,7 +49,7 @@ def write_visualization(settings: Settings, data: Data) -> None:
     ]
 
     # Only consider stages that contain finished suites
-    stage_starts: list[tuple[datetime, str]] = sorted(
+    stage_starts: "list[tuple[datetime, str]]" = sorted(
         [(s.t_start, s.name) for s in data.stages.values() if s.finished > 0]
     )
 
@@ -63,10 +60,17 @@ def write_visualization(settings: Settings, data: Data) -> None:
 
 
 def _create_plot(
-    path_svg: Path,
-    suites: list[Suite],
-    stage_starts: list[tuple[datetime, str]],
+    path_svg: "Path",
+    suites: "list[Suite]",
+    stage_starts: "list[tuple[datetime, str]]",
 ) -> None:
+    import matplotlib.pyplot as plt
+    from matplotlib.dates import (
+        MICROSECONDLY,
+        AutoDateLocator,
+        ConciseDateFormatter,
+    )
+
     deps = _get_sorted_deps(suites)
 
     bar_count = len(deps)
@@ -143,7 +147,9 @@ def _create_plot(
     plt.savefig(path_svg, bbox_inches="tight")
 
 
-def _add_hover_effects(path_svg: Path, suites: list[Suite]) -> None:
+def _add_hover_effects(path_svg: "Path", suites: "list[Suite]") -> None:
+    import xml.etree.ElementTree as ET
+
     # Prevent ugly namespace names in XML output
     ns = {
         "": "http://www.w3.org/2000/svg",
@@ -192,9 +198,11 @@ def _add_hover_effects(path_svg: Path, suites: list[Suite]) -> None:
     tree.write(path_svg, encoding="utf-8")
 
 
-def _get_sorted_deps(suites: list[Suite]) -> list[str]:
+def _get_sorted_deps(suites: "list[Suite]") -> list[str]:
     """Returns list of dependencies sorted descending by time in use."""
-    durations: dict[str, timedelta] = {}
+    from datetime import timedelta
+
+    durations: "dict[str, timedelta]" = {}
 
     for s in suites:
         for d in s.deps:


### PR DESCRIPTION
Do some imports at a smaller scope, especially in main.py to speed things up.

Also use `if TYPE_CHECKING` before imports that are only used for type hints to reduce some more import overhead.

This speeds some commands up significantly because we previously imported everything at once at program starting time, leading to a significant delay even for just `medusa version`.